### PR TITLE
Polish reusable authoring workflow UX

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>About | Nostr Site Template</title>
   <meta name="description" content="About the Nostr Site template and the kinds of projects it is meant to support.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">

--- a/admin.html
+++ b/admin.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Log In | Nostr Site Template</title>
   <meta name="description" content="Log in to manage your profile, comments, submissions, and role-based workspace tools.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">

--- a/blog.html
+++ b/blog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Blog | Nostr Site Template</title>
   <meta name="description" content="Browse sample blog posts in the Nostr Site template.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">
@@ -37,7 +37,10 @@
 
       <section class="section">
         <div class="wrap page-layout">
-          <div class="story-list" data-blog-list></div>
+          <div class="story-list-shell">
+            <div class="story-list" data-blog-list></div>
+            <section class="surface-panel draft-archive" data-blog-drafts hidden></section>
+          </div>
           <aside class="surface-panel article-aside" data-authoring-panel hidden>
             <div class="eyebrow">For editors</div>
             <h3>Write in the full editor</h3>

--- a/editor.html
+++ b/editor.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Create Post | Nostr Site Template</title>
   <meta name="description" content="Write and review post drafts in the Nostr Site template.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">

--- a/get-involved.html
+++ b/get-involved.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Get Involved | Nostr Site Template</title>
   <meta name="description" content="Placeholder participation and support page for the Nostr Site template.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">

--- a/guide.html
+++ b/guide.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Guide | Nostr Site Template</title>
   <meta name="description" content="A markdown-backed guide page in the Nostr Site template.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Nostr Site Template</title>
   <meta name="description" content="A static-first Nostr-backed site template for archives, guides, submissions, maps, and lightweight moderation.">
   <meta name="theme-color" content="#121212">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">

--- a/investigation.html
+++ b/investigation.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=./post.html">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <title>Redirecting…</title>

--- a/investigations.html
+++ b/investigations.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=./blog.html">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <title>Redirecting…</title>

--- a/map.html
+++ b/map.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Map | Nostr Site Template</title>
   <meta name="description" content="Entity map and geographic index for the Nostr Site template.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">

--- a/merch.html
+++ b/merch.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Merch | Nostr Site Template</title>
   <meta name="description" content="Placeholder merch or outbound store page for the Nostr Site template.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">

--- a/post.html
+++ b/post.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Post | Nostr Site Template</title>
   <meta name="description" content="Sample detail page for a markdown-backed blog post in the Nostr Site template.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">

--- a/scripts/template/admin.js
+++ b/scripts/template/admin.js
@@ -262,9 +262,23 @@ function captureWorkspaceAccessState() {
     sessionPubkey: workspaceState.viewer?.pubkey || "",
     admin: currentUserIsAdmin(),
     inbox: currentUserHasInboxAccess(),
-    pendingRequest: currentUserPendingKeyRequest()?.id || "",
-    activeSitePubkey: activeSitePubkey(),
-    knownShares: workspaceState.siteKeyShares.map((share) => share.sitePubkey).sort()
+    activeSitePubkey: activeSitePubkey()
+  });
+}
+
+function captureWorkspaceDataState() {
+  const publicState = workspaceState.publicState || {};
+  return JSON.stringify({
+    tab: workspaceState.activeTab,
+    keyState: workspaceState.keyRequestState || "",
+    users: (publicState.users || []).map((user) => `${user.pubkey}:${user.isAdmin ? 1 : 0}:${user.submissionCount || 0}:${user.commentCount || 0}`),
+    pendingKeyRequests: (publicState.pendingAdminKeyRequests || []).map((request) => `${request.id}:${request.requester_pubkey}:${request.site_pubkey}`),
+    submissions: (workspaceState.inboxSubmissions || []).map((submission) => `${submission.id}:${submission.latest?.status || submission.status || ""}`),
+    entities: (publicState.entities || []).map((entity) => `${entity.slug}:${entity.status}`),
+    drafts: (publicState.drafts || []).map((draft) => `${draft.slug}:${draft.status}:${draft.id || draft.created_at || ""}`),
+    comments: (publicState.allComments || []).map((comment) => `${comment.id}:${comment.visibility || "visible"}`),
+    snapshot: publicState.snapshotInfo?.id || "",
+    metrics: publicState.metrics || {}
   });
 }
 
@@ -295,7 +309,8 @@ async function syncWorkspaceState(force = true) {
   }
   if (!getStoredSession()) return;
 
-  const before = captureWorkspaceAccessState();
+  const beforeAccess = captureWorkspaceAccessState();
+  const beforeData = captureWorkspaceDataState();
   workspaceState.backgroundSyncInFlight = true;
   let didRefresh = false;
   try {
@@ -306,10 +321,21 @@ async function syncWorkspaceState(force = true) {
     await maybeEnsureCurrentKeyRequest().catch(() => {
       workspaceState.keyRequestState = "error";
     });
-    const after = captureWorkspaceAccessState();
-    if (before !== after) {
+    if (currentUserHasInboxAccess()) {
+      workspaceState.inboxSubmissions = await loadInboxSubmissions(workspaceState.siteKeyShares).catch(() => []);
+    } else {
+      workspaceState.inboxSubmissions = [];
+    }
+    workspaceState.staticSlugs = await loadStaticSlugs().catch(() => []);
+    workspaceState.activeTab = chooseInitialTab(workspaceState.activeTab);
+    const afterAccess = captureWorkspaceAccessState();
+    const afterData = captureWorkspaceDataState();
+    if (beforeAccess !== afterAccess) {
       didRefresh = true;
-      await refreshWorkspace(true);
+      renderWorkspace({ soft: true });
+    } else if (beforeData !== afterData && shouldSoftRefreshWorkspace()) {
+      didRefresh = true;
+      renderWorkspace({ soft: true });
     }
   } finally {
     workspaceState.backgroundSyncInFlight = false;
@@ -317,7 +343,8 @@ async function syncWorkspaceState(force = true) {
   }
 }
 
-function renderWorkspace() {
+function renderWorkspace(options = {}) {
+  const soft = Boolean(options.soft);
   const shell = document.querySelector("[data-workspace-shell]");
   const title = document.querySelector("[data-workspace-title]");
   const lede = document.querySelector("[data-workspace-lede]");
@@ -336,16 +363,30 @@ function renderWorkspace() {
     ? "Manage users, submissions, entities, and post review."
     : "Update your profile and review your comments.";
 
-  shell.innerHTML = `
-    <div class="workspace-tabs">
-      ${tabButtons().map((tab) => renderTabButton(tab)).join("")}
-    </div>
-    <div class="workspace-pane">
-      ${renderActivePane()}
-    </div>
-    ${renderEntityModal()}
-    ${renderChatModal()}
-  `;
+  const tabsMarkup = tabButtons().map((tab) => renderTabButton(tab)).join("");
+  const paneMarkup = renderActivePane();
+  const overlayMarkup = `${renderEntityModal()}${renderChatModal()}`;
+  const tabs = shell.querySelector("[data-workspace-tabs]");
+  const pane = shell.querySelector("[data-workspace-pane]");
+  const overlays = shell.querySelector("[data-workspace-overlays]");
+
+  if (soft && tabs && pane && overlays) {
+    tabs.innerHTML = tabsMarkup;
+    pane.innerHTML = paneMarkup;
+    overlays.innerHTML = overlayMarkup;
+  } else {
+    shell.innerHTML = `
+      <div class="workspace-tabs" data-workspace-tabs>
+        ${tabsMarkup}
+      </div>
+      <div class="workspace-pane" data-workspace-pane>
+        ${paneMarkup}
+      </div>
+      <div data-workspace-overlays>
+        ${overlayMarkup}
+      </div>
+    `;
+  }
   hydrateWorkspaceEnhancements();
 }
 
@@ -1904,8 +1945,18 @@ async function maybeEnsureCurrentKeyRequest() {
 
   workspaceState.keyRequestState = "pending";
   workspaceState.keyRequestTimer = window.setTimeout(() => {
-    void refreshWorkspace(true);
+    void syncWorkspaceState(true);
   }, 3200);
+}
+
+function shouldSoftRefreshWorkspace() {
+  if (workspaceState.entityModal || workspaceState.chatModal) return false;
+  const active = document.activeElement;
+  return !(
+    active instanceof HTMLElement &&
+    active.closest("[data-workspace-shell]") &&
+    active.matches("input, textarea, select, [contenteditable='true']")
+  );
 }
 
 async function loadStaticSlugs() {

--- a/scripts/template/app.js
+++ b/scripts/template/app.js
@@ -166,7 +166,21 @@ function renderNavigation() {
 
   nav.innerHTML = `
     <a class="${navLinkClass(page, "home")}" href="./index.html">Home</a>
-    <a class="${navLinkClass(page, "blog")}" href="./blog.html">Blog</a>
+    ${
+      isAdmin
+        ? `
+          <div class="nav-group ${NAV_KEYS.blog.includes(page) ? "is-current" : ""}" data-nav-group>
+            <button class="nav-group__toggle" type="button" data-submenu-toggle>
+              Blog
+            </button>
+            <div class="nav-group__panel">
+              <a class="${navLinkClass(page, "blog")}" href="./blog.html">View Blog</a>
+              <a href="./editor.html">Create Post</a>
+            </div>
+          </div>
+        `
+        : `<a class="${navLinkClass(page, "blog")}" href="./blog.html">Blog</a>`
+    }
     <a class="${navLinkClass(page, "map", !mapEnabled && !mapCurrent)}" href="./map.html" ${!mapEnabled && !mapCurrent ? 'aria-disabled="true"' : ""}>Map</a>
     <div class="nav-group ${NAV_KEYS["get-involved"].includes(page) ? "is-current" : ""}" data-nav-group>
       <button class="nav-group__toggle" type="button" data-submenu-toggle>
@@ -243,10 +257,13 @@ function initExternalLinks() {
 async function initBlogCards() {
   const homeGrid = document.querySelector("[data-home-posts]");
   const listGrid = document.querySelector("[data-blog-list]");
-  if (!homeGrid && !listGrid) return;
+  const draftHost = document.querySelector("[data-blog-drafts]");
+  if (!homeGrid && !listGrid && !draftHost) return;
 
   try {
     const posts = await loadPosts();
+    const publicState = await getPublicState();
+    const canEdit = editorEntryAllowed(publicState);
     if (homeGrid) {
       const count = Number(homeGrid.getAttribute("data-count") || "2");
       homeGrid.innerHTML = posts
@@ -258,8 +275,13 @@ async function initBlogCards() {
     if (listGrid) {
       listGrid.innerHTML = posts.map((post) => renderPostCard(post, false)).join("");
     }
+    if (draftHost instanceof HTMLElement) {
+      const drafts = canEdit ? buildDraftArchiveEntries(publicState.drafts || []) : [];
+      draftHost.hidden = !drafts.length;
+      draftHost.innerHTML = drafts.length ? renderDraftArchive(drafts) : "";
+    }
   } catch {
-    renderError(homeGrid || listGrid, "Blog feed unavailable.");
+    renderError(homeGrid || listGrid || draftHost, "Blog feed unavailable.");
   }
 }
 
@@ -615,32 +637,67 @@ function renderAvatarBadge(user, fallbackLabel, className) {
 }
 
 function renderPostCard(post, compact) {
+  const href = post.href || `./post.html?slug=${encodeURIComponent(post.slug)}`;
+  const eyebrow = post.eyebrow || "Blog post";
+  const actionLabel = post.actionLabel || "Open post";
   if (!compact) {
     return `
       <article class="post-card post-card--list">
         <div class="post-card__body">
-          <div class="eyebrow">Blog post</div>
-          <h3><a href="./post.html?slug=${encodeURIComponent(post.slug)}">${escapeHtml(post.title)}</a></h3>
+          <div class="eyebrow">${escapeHtml(eyebrow)}</div>
+          <h3><a href="${href}">${escapeHtml(post.title)}</a></h3>
           <p class="card-meta">${escapeHtml(post.location)} <span>${escapeHtml(formatDate(post.date))}</span></p>
           <p class="card-summary">${escapeHtml(post.summary)}</p>
           <div class="tag-row">${renderTagList((post.tags || []).slice(0, 4))}</div>
         </div>
         <div class="post-card__rail">
-          <a class="text-link" href="./post.html?slug=${encodeURIComponent(post.slug)}">Open post</a>
+          <a class="text-link" href="${href}">${escapeHtml(actionLabel)}</a>
         </div>
       </article>
     `;
   }
   return `
     <article class="post-card ${compact ? "post-card--compact" : ""}">
-      <div class="eyebrow">Blog post</div>
-      <h3><a href="./post.html?slug=${encodeURIComponent(post.slug)}">${escapeHtml(post.title)}</a></h3>
+      <div class="eyebrow">${escapeHtml(eyebrow)}</div>
+      <h3><a href="${href}">${escapeHtml(post.title)}</a></h3>
       <p class="card-meta">${escapeHtml(post.location)} <span>${escapeHtml(formatDate(post.date))}</span></p>
       <p>${escapeHtml(post.summary)}</p>
       <div class="tag-row">${renderTagList((post.tags || []).slice(0, compact ? 2 : 4))}</div>
-      <a class="text-link" href="./post.html?slug=${encodeURIComponent(post.slug)}">Open post</a>
+      <a class="text-link" href="${href}">${escapeHtml(actionLabel)}</a>
     </article>
   `;
+}
+
+function buildDraftArchiveEntries(drafts) {
+  return (Array.isArray(drafts) ? drafts : [])
+    .map((draft) => ({
+      ...draft,
+      eyebrow: draftStatusLabel(draft.status),
+      actionLabel: "Open draft",
+      href: `./editor.html?slug=${encodeURIComponent(draft.slug)}`,
+      location: draft.location || "Draft location pending",
+      summary: draft.summary || "This draft does not have a summary yet."
+    }))
+    .sort((left, right) => String(right.date || "").localeCompare(String(left.date || "")));
+}
+
+function renderDraftArchive(drafts) {
+  return `
+    <div class="eyebrow">Drafts</div>
+    <h3>Working drafts and review queue</h3>
+    <p class="muted-text">Only admins can see this section. Open any draft to keep writing or send it forward.</p>
+    <div class="story-list story-list--drafts">
+      ${drafts.map((draft) => renderPostCard(draft, false)).join("")}
+    </div>
+  `;
+}
+
+function draftStatusLabel(status) {
+  const clean = String(status || "").trim().toLowerCase();
+  if (["candidate", "review", "submitted"].includes(clean)) return "In review";
+  if (clean === "approved") return "Approved for snapshot";
+  if (clean === "rejected") return "Sent back";
+  return "Working draft";
 }
 
 function renderRecordList(records) {

--- a/scripts/template/editor.js
+++ b/scripts/template/editor.js
@@ -22,7 +22,11 @@ const editorState = {
   relayTimer: 0,
   lastLocalFingerprint: "",
   lastRelayFingerprint: "",
-  draftStatus: "draft"
+  draftStatus: "draft",
+  activePickerField: "",
+  entityModal: null,
+  modalRoot: null,
+  documentClicksBound: false
 };
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -125,19 +129,18 @@ function renderEditorShell() {
           </label>
           <label class="editor-field editor-field--compact">
             <span class="sr-only">Lead entity</span>
-            <input name="primaryEntity" type="text" data-editor-entity-input="primaryEntity" placeholder="Lead entity" value="${escapeAttribute(editorState.document.primaryEntity)}">
+            <div class="editor-picker" data-editor-picker="primaryEntity">
+              <input name="primaryEntity" type="text" data-editor-entity-input="primaryEntity" autocomplete="off" placeholder="Lead entity" value="${escapeAttribute(editorState.document.primaryEntity)}">
+              <div class="picker-results picker-results--dropdown" data-editor-entity-results="primaryEntity"></div>
+            </div>
           </label>
           <label class="editor-field editor-field--compact editor-field--wide">
             <span class="sr-only">Related entities</span>
-            <input name="entityRefs" type="text" data-editor-entity-input="entityRefs" placeholder="Related entities" value="${escapeAttribute(editorState.document.entityRefs.join(", "))}">
+            <div class="editor-picker" data-editor-picker="entityRefs">
+              <input name="entityRefs" type="text" data-editor-entity-input="entityRefs" autocomplete="off" placeholder="Related entities" value="${escapeAttribute(editorState.document.entityRefs.join(", "))}">
+              <div class="picker-results picker-results--dropdown" data-editor-entity-results="entityRefs"></div>
+            </div>
           </label>
-        </div>
-
-        <div class="picker-results" data-editor-entity-results="primaryEntity"></div>
-        <div class="picker-results" data-editor-entity-results="entityRefs"></div>
-
-        <div class="editor-inline-note">
-          Need a new entity? <a class="text-link" href="./admin.html?tab=entities">Add it in Entities</a> and come back here.
         </div>
 
         <div class="editor-markdown-field" role="group" aria-label="Body">
@@ -149,6 +152,7 @@ function renderEditorShell() {
   `;
 
   bindEditorShell();
+  renderEntityModal();
   updateMetaPanel();
   updateHistoryPanels();
   hydrateEntityResults();
@@ -179,14 +183,14 @@ function bindEditorShell() {
     usageStatistics: false,
     placeholder: "Write the full post here. Use headings, quotes, links, and lists.",
     toolbarItems: [
-      ["heading", "bold", "italic", "strike"],
-      ["hr", "quote"],
-      ["ul", "ol", "task", "indent", "outdent"],
+      ["heading", "bold", "italic"],
+      ["quote", "ul", "ol"],
       ["link"],
       ["code", "codeblock"]
     ]
   });
   surface.__cmsEditor = editorState.editor;
+  decorateToolbar(surface);
 
   const queueSave = () => {
     syncSlugPreview();
@@ -197,6 +201,14 @@ function bindEditorShell() {
 
   form.addEventListener("input", queueSave);
   editorState.editor.on("change", queueSave);
+  form.addEventListener("focusin", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (target.matches("[data-editor-entity-input]")) {
+      editorState.activePickerField = target.getAttribute("data-editor-entity-input") || "";
+      hydrateEntityResults();
+    }
+  });
 
   form.addEventListener("click", async (event) => {
     const target = event.target;
@@ -220,6 +232,12 @@ function bindEditorShell() {
       return;
     }
 
+    const createEntity = target.closest("[data-editor-create-entity]");
+    if (createEntity) {
+      openEntityModal(createEntity.getAttribute("data-editor-create-entity") || "");
+      return;
+    }
+
     if (target.closest("[data-editor-save]")) {
       await saveDraftNow("draft");
       return;
@@ -229,6 +247,11 @@ function bindEditorShell() {
       await saveDraftNow("candidate");
     }
   });
+
+  if (!editorState.documentClicksBound) {
+    document.addEventListener("click", handleDocumentClick, true);
+    editorState.documentClicksBound = true;
+  }
 }
 
 function hydrateDraftState() {
@@ -485,23 +508,33 @@ function renderEntityResults(fieldName) {
   const input = document.querySelector(`[name="${fieldName}"]`);
   if (!(host instanceof HTMLElement) || !(input instanceof HTMLInputElement)) return;
   const query = fieldName === "entityRefs" ? lastCommaValue(input.value) : input.value.trim();
-  if (!query) {
+  const isActive = editorState.activePickerField === fieldName;
+  if (!query && !isActive) {
     host.innerHTML = "";
+    host.removeAttribute("data-open");
     return;
   }
   const matches = matchEntities(query).slice(0, 6);
-  host.innerHTML = matches.length
-    ? matches
-        .map(
-          (entity) => `
-            <button class="picker-chip" type="button" data-editor-entity-pick="${escapeAttribute(entity.slug)}" data-target-field="${fieldName}">
-              <strong>${escapeHtml(entity.name)}</strong>
-              <span>${escapeHtml(entity.location)}</span>
-            </button>
-          `
-        )
-        .join("")
-    : `<div class="picker-hint">No match found yet.</div>`;
+  const createLabel = query ? `Add "${query}" as a new entity` : "Add a new entity";
+  host.setAttribute("data-open", "true");
+  host.innerHTML = `
+    ${matches.length
+      ? matches
+          .map(
+            (entity) => `
+              <button class="picker-chip" type="button" data-editor-entity-pick="${escapeAttribute(entity.slug)}" data-target-field="${fieldName}">
+                <strong>${escapeHtml(entity.name)}</strong>
+                <span>${escapeHtml(entity.location || entity.type || "Entity")}</span>
+              </button>
+            `
+          )
+          .join("")
+      : `<div class="picker-hint">${query ? "No saved entity matches that search yet." : "Start typing to search existing entities."}</div>`}
+    <button class="picker-create" type="button" data-editor-create-entity="${fieldName}">
+      <strong>${escapeHtml(createLabel)}</strong>
+      <span>Create it here</span>
+    </button>
+  `;
 }
 
 function applyEntityPick(button) {
@@ -516,13 +549,19 @@ function applyEntityPick(button) {
   } else {
     input.value = entity.name;
   }
+  editorState.activePickerField = "";
   hydrateEntityResults();
 }
 
 function matchEntities(query) {
   const clean = String(query || "").trim().toLowerCase();
-  if (!clean) return [];
-  return (editorState.publicState?.approvedEntities || []).filter((entity) => {
+  const entities = (editorState.publicState?.approvedEntities || []).slice().sort((left, right) => {
+    const leftName = String(left?.name || "").toLowerCase();
+    const rightName = String(right?.name || "").toLowerCase();
+    return leftName.localeCompare(rightName);
+  });
+  if (!clean) return entities;
+  return entities.filter((entity) => {
     const values = [
       entity.name,
       entity.slug,
@@ -533,6 +572,243 @@ function matchEntities(query) {
       .filter(Boolean);
     return values.some((value) => value.includes(clean));
   });
+}
+
+function openEntityModal(fieldName) {
+  editorState.entityModal = createEntityModalState(fieldName);
+  renderEntityModal();
+}
+
+function closeEntityModal() {
+  editorState.entityModal = null;
+  renderEntityModal();
+}
+
+function createEntityModalState(fieldName) {
+  const input = document.querySelector(`[name="${fieldName}"]`);
+  const rawValue = input instanceof HTMLInputElement ? input.value.trim() : "";
+  return {
+    fieldName,
+    seedName: fieldName === "entityRefs" ? lastCommaValue(rawValue) : rawValue,
+    seedLocation: "",
+    seedType: "",
+    seedNotes: ""
+  };
+}
+
+function renderEntityModal() {
+  const root = ensureModalRoot();
+  if (!editorState.entityModal) {
+    root.innerHTML = "";
+    return;
+  }
+  const { seedName, seedLocation, seedType, seedNotes } = editorState.entityModal;
+  root.innerHTML = `
+    <div class="modal-backdrop" data-editor-modal-backdrop>
+      <section class="modal-card modal-card--editor" aria-label="Add entity">
+        <div class="section-heading">
+          <div>
+            <div class="eyebrow">Add entity</div>
+            <h3>Create an entity without leaving the draft</h3>
+            <p>Save it once, then keep writing.</p>
+          </div>
+          <button class="button-ghost" type="button" data-editor-modal-close>Close</button>
+        </div>
+        <form class="form-grid editor-entity-form" data-editor-entity-form>
+          <label>
+            <span class="sr-only">Entity name</span>
+            <input name="name" type="text" maxlength="120" placeholder="Entity name" value="${escapeAttribute(seedName)}" required>
+          </label>
+          <label>
+            <span class="sr-only">Entity type</span>
+            <input name="type" type="text" maxlength="80" placeholder="Type: organization, location, campaign" value="${escapeAttribute(seedType)}">
+          </label>
+          <label class="editor-field editor-field--wide">
+            <span class="sr-only">Location</span>
+            <div class="editor-picker editor-picker--modal">
+              <input name="location" type="text" maxlength="160" data-editor-location-input autocomplete="off" placeholder="Location" value="${escapeAttribute(seedLocation)}">
+              <div class="picker-results picker-results--dropdown" data-editor-location-results></div>
+            </div>
+          </label>
+          <label class="editor-field editor-field--compact">
+            <span class="sr-only">Latitude</span>
+            <input name="lat" type="text" inputmode="decimal" placeholder="Latitude (optional)">
+          </label>
+          <label class="editor-field editor-field--compact">
+            <span class="sr-only">Longitude</span>
+            <input name="lng" type="text" inputmode="decimal" placeholder="Longitude (optional)">
+          </label>
+          <label class="editor-field editor-field--wide">
+            <span class="sr-only">Notes</span>
+            <textarea name="notes" rows="4" placeholder="Notes for editors or map context">${escapeHtml(seedNotes)}</textarea>
+          </label>
+          <div class="button-row">
+            <button class="button-ghost" type="button" data-editor-modal-close>Cancel</button>
+            <button class="button" type="submit">Save entity</button>
+          </div>
+        </form>
+      </section>
+    </div>
+  `;
+  bindEntityModal();
+  renderLocationResults();
+}
+
+function bindEntityModal() {
+  const root = ensureModalRoot();
+  const form = root.querySelector("[data-editor-entity-form]");
+  if (!(form instanceof HTMLFormElement)) return;
+  root.onclick = (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (target.matches("[data-editor-modal-backdrop]")) {
+      closeEntityModal();
+      return;
+    }
+    if (target.closest("[data-editor-modal-close]")) {
+      closeEntityModal();
+      return;
+    }
+    const locationPick = target.closest("[data-editor-location-pick]");
+    if (locationPick) {
+      applyLocationPick(locationPick);
+    }
+  };
+  form.oninput = (event) => {
+    const target = event.target;
+    if (target instanceof HTMLInputElement && target.matches("[data-editor-location-input]")) {
+      renderLocationResults();
+    }
+  };
+  form.onsubmit = async (event) => {
+    event.preventDefault();
+    await handleEntitySave(form);
+  };
+}
+
+async function handleEntitySave(form) {
+  if (!editorState.session || !currentUserIsAdmin()) return;
+  const formData = new FormData(form);
+  const name = String(formData.get("name") || "").trim();
+  if (!name) return;
+  const taken = (editorState.publicState?.entities || []).map((entity) => entity.slug);
+  const slug = createUniqueSlug(name, taken);
+  const entity = {
+    slug,
+    name,
+    location: String(formData.get("location") || "").trim(),
+    type: String(formData.get("type") || "").trim() || "entity",
+    lat: parseMaybeNumber(formData.get("lat")),
+    lng: parseMaybeNumber(formData.get("lng")),
+    notes: String(formData.get("notes") || "").trim(),
+    aliases: [],
+    status: "approved"
+  };
+  await publishTaggedJson({
+    kind: SITE.nostr.kinds.entity,
+    secretKeyHex: editorState.session.secretKeyHex,
+    tags: [["d", slug]],
+    content: entity
+  });
+  mergeEntityIntoState(entity);
+  applyNewEntityToField(entity, editorState.entityModal?.fieldName || "");
+  closeEntityModal();
+  setEditorStatus(`Saved ${entity.name}.`, "success");
+}
+
+function mergeEntityIntoState(entity) {
+  if (!editorState.publicState) return;
+  const nextEntities = [
+    ...(editorState.publicState.entities || []).filter((item) => item.slug !== entity.slug),
+    entity
+  ].sort((left, right) => String(left.name || "").localeCompare(String(right.name || "")));
+  editorState.publicState.entities = nextEntities;
+  editorState.publicState.approvedEntities = nextEntities.filter((item) => item.status === "approved");
+}
+
+function applyNewEntityToField(entity, fieldName) {
+  const input = document.querySelector(`[name="${fieldName}"]`);
+  if (!(input instanceof HTMLInputElement)) return;
+  if (fieldName === "entityRefs") {
+    const existing = splitTags(input.value)
+      .map((value) => resolveEntityByNameOrSlug(value)?.name || value)
+      .filter(Boolean);
+    input.value = dedupe([...existing, entity.name]).join(", ");
+  } else {
+    input.value = entity.name;
+  }
+  editorState.activePickerField = fieldName;
+  hydrateEntityResults();
+}
+
+function renderLocationResults() {
+  const host = document.querySelector("[data-editor-location-results]");
+  const input = document.querySelector("[data-editor-location-input]");
+  if (!(host instanceof HTMLElement) || !(input instanceof HTMLInputElement)) return;
+  const query = input.value.trim();
+  const matches = uniqueLocations(query).slice(0, 6);
+  if (!query && !matches.length) {
+    host.innerHTML = "";
+    host.removeAttribute("data-open");
+    return;
+  }
+  host.setAttribute("data-open", "true");
+  host.innerHTML = `
+    ${matches.length
+      ? matches
+          .map(
+            (location) => `
+              <button class="picker-chip" type="button" data-editor-location-pick="${escapeAttribute(location)}">
+                <strong>${escapeHtml(location)}</strong>
+              </button>
+            `
+          )
+          .join("")
+      : `<div class="picker-hint">${query ? "No saved location matches yet." : "Start typing to reuse a location."}</div>`}
+    ${query
+      ? `<button class="picker-create" type="button" data-editor-location-pick="${escapeAttribute(query)}">
+          <strong>Use "${escapeHtml(query)}"</strong>
+          <span>Keep this exact location</span>
+        </button>`
+      : ""}
+  `;
+}
+
+function applyLocationPick(button) {
+  const value = button.getAttribute("data-editor-location-pick") || "";
+  const input = document.querySelector("[data-editor-location-input]");
+  if (!(input instanceof HTMLInputElement)) return;
+  input.value = value;
+  renderLocationResults();
+}
+
+function uniqueLocations(query = "") {
+  const clean = String(query || "").trim().toLowerCase();
+  const values = dedupe((editorState.publicState?.entities || []).map((entity) => entity.location));
+  if (!clean) return values;
+  return values.filter((location) => location.toLowerCase().includes(clean));
+}
+
+function ensureModalRoot() {
+  if (editorState.modalRoot instanceof HTMLElement) return editorState.modalRoot;
+  const existing = document.querySelector("[data-editor-modal-root]");
+  if (existing instanceof HTMLElement) {
+    editorState.modalRoot = existing;
+    return existing;
+  }
+  const root = document.createElement("div");
+  root.dataset.editorModalRoot = "";
+  document.body.append(root);
+  editorState.modalRoot = root;
+  return root;
+}
+
+function handleDocumentClick(event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  if (target.closest("[data-editor-picker]") || target.closest("[data-editor-modal-root]")) return;
+  editorState.activePickerField = "";
+  hydrateEntityResults();
 }
 
 function resolveEntityByNameOrSlug(value) {
@@ -642,6 +918,11 @@ function lastCommaValue(value) {
   return String(value || "").split(",").pop().trim();
 }
 
+function parseMaybeNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
 function dedupe(values) {
   return [...new Set((Array.isArray(values) ? values : []).map((value) => String(value || "").trim()).filter(Boolean))];
 }
@@ -678,4 +959,23 @@ function escapeHtml(value) {
 
 function escapeAttribute(value) {
   return escapeHtml(value);
+}
+
+function decorateToolbar(surface) {
+  const labels = new Map([
+    ["Headings", "Headings"],
+    ["Bold", "Bold"],
+    ["Italic", "Italic"],
+    ["Blockquote", "Quote"],
+    ["Unordered list", "Bullets"],
+    ["Ordered list", "Numbers"],
+    ["Insert link", "Link"],
+    ["Inline code", "Code"],
+    ["Insert codeBlock", "Code block"],
+    ["Insert code block", "Code block"]
+  ]);
+  surface.querySelectorAll(".toastui-editor-defaultUI-toolbar button").forEach((button) => {
+    const label = labels.get(String(button.getAttribute("aria-label") || "").trim());
+    if (label) button.setAttribute("data-button-label", label);
+  });
 }

--- a/styles.css
+++ b/styles.css
@@ -560,6 +560,21 @@ h3 {
   gap: 1rem;
 }
 
+.story-list-shell {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.draft-archive {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.35rem;
+}
+
+.story-list--drafts {
+  margin-top: 0.2rem;
+}
+
 .post-card,
 .article-card {
   padding: 1.5rem;
@@ -871,6 +886,7 @@ h3 {
 .editor-studio {
   display: grid;
   gap: 1.4rem;
+  padding: 1.35rem;
 }
 
 .editor-form--studio {
@@ -941,11 +957,6 @@ h3 {
   color: var(--ink);
 }
 
-.editor-inline-note {
-  color: var(--ink-soft);
-  font-size: 0.95rem;
-}
-
 .editor-field {
   display: grid;
   gap: 0.4rem;
@@ -1000,6 +1011,10 @@ h3 {
   grid-column: 1 / -1;
 }
 
+.editor-picker {
+  position: relative;
+}
+
 .editor-markdown-field {
   display: grid;
   gap: 0.6rem;
@@ -1017,41 +1032,78 @@ h3 {
 
 .editor-markdown-field .toastui-editor-defaultUI {
   border: 1px solid var(--line);
-  border-radius: 24px;
+  border-radius: 26px;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.88);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 244, 238, 0.98));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.45),
+    0 16px 40px rgba(18, 18, 18, 0.07);
 }
 
 .editor-markdown-field .toastui-editor-defaultUI-toolbar {
-  border-bottom: 1px solid var(--line);
-  background: rgba(18, 18, 18, 0.03);
-  padding: 0.9rem 1rem 0.7rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+  border-bottom: 1px solid rgba(18, 18, 18, 0.08);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(243, 238, 231, 0.96));
+  padding: 0.95rem 1rem;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-group {
-  margin-right: 0.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding-right: 0.75rem;
+  border-right: 1px solid rgba(18, 18, 18, 0.08);
+}
+
+.editor-markdown-field .toastui-editor-toolbar-group:last-child {
+  border-right: 0;
+  padding-right: 0;
 }
 
 .editor-markdown-field .toastui-editor-defaultUI-toolbar button {
-  width: 2.35rem;
-  height: 2.35rem;
-  margin: 0 0.22rem 0.32rem 0;
+  width: auto;
+  min-width: 0;
+  height: 2.5rem;
+  margin: 0;
+  padding: 0 0.9rem;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-icons,
 .editor-markdown-field .toastui-editor-toolbar-icons.last {
   border-radius: 999px;
   border: 1px solid rgba(18, 18, 18, 0.08);
-  background-color: rgba(255, 255, 255, 0.76);
+  background-color: rgba(255, 255, 255, 0.9);
+  background-image: none !important;
+  color: var(--ink);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-indent: 0;
+  white-space: nowrap;
+}
+
+.editor-markdown-field .toastui-editor-toolbar-icons::before,
+.editor-markdown-field .toastui-editor-toolbar-icons.last::before {
+  content: attr(data-button-label);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-icons:hover,
 .editor-markdown-field .toastui-editor-toolbar-icons.active,
 .editor-markdown-field .toastui-editor-toolbar-icons.last:hover,
 .editor-markdown-field .toastui-editor-toolbar-icons.last.active {
-  background-color: rgba(156, 29, 24, 0.08);
-  border-color: rgba(156, 29, 24, 0.16);
+  background-color: rgba(156, 29, 24, 0.1);
+  border-color: rgba(156, 29, 24, 0.22);
+}
+
+.editor-markdown-field .toastui-editor-toolbar-divider {
+  display: none;
 }
 
 .editor-markdown-field .toastui-editor-main {
@@ -1063,6 +1115,11 @@ h3 {
 .editor-markdown-field .toastui-editor-md-container,
 .editor-markdown-field .toastui-editor-ww-container {
   background: transparent;
+}
+
+.editor-markdown-field .toastui-editor-ww-container .ProseMirror,
+.editor-markdown-field .toastui-editor-md-container .toastui-editor-md-preview {
+  padding: 1.6rem 1.8rem 2.2rem;
 }
 
 .editor-markdown-field .toastui-editor-mode-switch {
@@ -1139,6 +1196,26 @@ h3 {
 .editor-markdown-field .toastui-editor-popup {
   border-radius: 18px;
   border-color: rgba(18, 18, 18, 0.08);
+}
+
+.editor-entity-form {
+  margin-top: 1rem;
+}
+
+.editor-entity-form input,
+.editor-entity-form textarea {
+  width: 100%;
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--ink);
+  font: inherit;
+}
+
+.editor-entity-form textarea {
+  min-height: 7rem;
+  resize: vertical;
 }
 
 .map-shell,
@@ -1450,6 +1527,18 @@ h3 {
   margin-top: 0.6rem;
 }
 
+.picker-results--dropdown {
+  padding: 0.5rem;
+  border-radius: 18px;
+  border: 1px solid rgba(18, 18, 18, 0.08);
+  background: rgba(250, 247, 241, 0.96);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.picker-results--dropdown:not([data-open]) {
+  display: none;
+}
+
 .picker-chip {
   display: flex;
   align-items: center;
@@ -1467,6 +1556,30 @@ h3 {
 
 .picker-chip strong {
   font-size: 0.95rem;
+}
+
+.picker-create {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+  width: 100%;
+  padding: 0.8rem 0.95rem;
+  border-radius: 14px;
+  border: 1px dashed rgba(156, 29, 24, 0.3);
+  background: rgba(156, 29, 24, 0.06);
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+}
+
+.picker-create strong {
+  font-size: 0.95rem;
+}
+
+.picker-create span {
+  color: var(--accent-deep);
+  font-size: 0.84rem;
 }
 
 .picker-chip span {
@@ -1505,6 +1618,10 @@ h3 {
 
 .modal-card--wide {
   width: min(56rem, calc(100vw - 2rem));
+}
+
+.modal-card--editor {
+  width: min(42rem, calc(100vw - 2rem));
 }
 
 .chat-thread,

--- a/submit.html
+++ b/submit.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Submit | Nostr Site Template</title>
   <meta name="description" content="Private submission flow for the Nostr Site template.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; connect-src 'self' https: wss:; font-src 'self' data: https:; object-src 'none'; media-src 'self' blob: https:; manifest-src 'self'; worker-src 'self' blob:;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
   <link rel="stylesheet" href="./styles.css">


### PR DESCRIPTION
Closes #3

## What changed
- cleaned up the generic editor shell and toolbar presentation
- moved entity search/create inline inside the editor flow
- added admin-aware content navigation for the primary archive section
- surfaced draft entries on the archive index for editors
- softened workspace background refresh behavior so polling is less disruptive
- aligned static page CSP with the intended typography assets