### PR TITLE
Harden demo editor Firefox toolbar styling

### DIFF
--- a/scripts/template/editor.js
+++ b/scripts/template/editor.js
@@ -989,6 +989,16 @@ function decorateToolbar(surface) {
   ]);
   surface.querySelectorAll(".toastui-editor-defaultUI-toolbar button").forEach((button) => {
     const label = labels.get(String(button.getAttribute("aria-label") || "").trim());
-    if (label) button.setAttribute("data-button-label", label);
+    if (!label) return;
+    button.classList.add("editor-toolbar-button");
+    const icon = button.querySelector(".toastui-editor-toolbar-icons, .toastui-editor-toolbar-icons.last");
+    if (icon instanceof HTMLElement) {
+      icon.textContent = label;
+      icon.setAttribute("aria-hidden", "true");
+      icon.setAttribute("title", "");
+      icon.classList.add("editor-toolbar-chip");
+    } else {
+      button.textContent = label;
+    }
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -1156,9 +1156,9 @@ h3 {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.55rem;
   border-bottom: 1px solid rgba(18, 18, 18, 0.08);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(243, 238, 231, 0.96));
+  background: #fff;
   padding: 0.95rem 1rem;
 }
 
@@ -1177,30 +1177,47 @@ h3 {
 }
 
 .editor-markdown-field .toastui-editor-defaultUI-toolbar button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: auto;
   min-width: 0;
-  height: 2.5rem;
+  height: auto;
   margin: 0;
-  padding: 0 0.9rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-icons,
 .editor-markdown-field .toastui-editor-toolbar-icons.last {
   border-radius: 999px;
   border: 1px solid rgba(18, 18, 18, 0.08);
-  background-color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.98);
   background-image: none !important;
   color: var(--ink);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  text-indent: 0;
+  width: auto !important;
+  min-width: 0;
+  height: 2.6rem !important;
+  padding: 0 1rem;
+  text-indent: 0 !important;
   white-space: nowrap;
+  overflow: visible;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.82rem !important;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-icons::before,
 .editor-markdown-field .toastui-editor-toolbar-icons.last::before {
-  content: attr(data-button-label);
+  content: none;
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -1221,21 +1238,37 @@ h3 {
 .editor-markdown-field .toastui-editor-main {
   min-height: 34rem;
   border: 0;
+  background: #fff;
 }
 
 .editor-markdown-field .toastui-editor-main-container,
 .editor-markdown-field .toastui-editor-md-container,
 .editor-markdown-field .toastui-editor-ww-container {
-  background: transparent;
+  background: #fff;
 }
 
 .editor-markdown-field .toastui-editor-ww-container .ProseMirror,
 .editor-markdown-field .toastui-editor-md-container .toastui-editor-md-preview {
   padding: 1.6rem 1.8rem 2.2rem;
+  min-height: 34rem;
+  background: #fff;
 }
 
 .editor-markdown-field .toastui-editor-mode-switch {
   display: none;
+}
+
+.editor-markdown-field .toastui-editor-md-tab-container,
+.editor-markdown-field .toastui-editor-tabs {
+  display: none !important;
+}
+
+.editor-markdown-field .toastui-editor-ww-container {
+  border-top: 0 !important;
+}
+
+.editor-markdown-field .toastui-editor-ww-container .ProseMirror {
+  outline: none;
 }
 
 .editor-markdown-field .toastui-editor-contents {


### PR DESCRIPTION
## Summary\n- replace the pseudo-element toolbar label hack with real button text in the demo editor\n- clean the Toast editor shell so Firefox renders a plain white writing surface\n- keep the markdown-backed editing flow intact while matching the truecost fix where it is reusable\n\n## Testing\n- node --check scripts/template/editor.js\n- npm run build